### PR TITLE
zmiana czcionki stopki

### DIFF
--- a/layouts/partials/sections/footer/copyright.html
+++ b/layouts/partials/sections/footer/copyright.html
@@ -1,4 +1,4 @@
-<div class="container py-4">
+<div class="container py-4 primary-font">
     <div class="row justify-content-center">
         <div class="col-md-4 text-center">
             <div class="pb-2">


### PR DESCRIPTION
Do stopki(`copyright.html`) dodana została klasa aplikująca główną czcionkę.
Przed:
![before](https://github.com/knmlprz/knml.edu.pl/assets/62908964/d790a1c2-1d9d-4369-b693-94f7862a683f)
Po:
![after](https://github.com/knmlprz/knml.edu.pl/assets/62908964/da479df0-5a27-4085-8b56-ad4ebfe5e469)
